### PR TITLE
[Bug]: Fix import of location module

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,12 @@ general.set_nprocs(2)
 ```
 
 ## DEV setup
-
+pip-tools is required for DEV setup: 
+```bash
+# only once
+pip3 install pip-tools
+```
+then install grass-gis-helpers from the local repository:
 ```bash
 pip3 install -e .
 

--- a/src/grass_gis_helpers/cleanup.py
+++ b/src/grass_gis_helpers/cleanup.py
@@ -20,7 +20,7 @@ import os
 import shutil
 import gc
 
-from location import get_location_size
+from .location import get_location_size
 
 import grass.script as grass
 


### PR DESCRIPTION
This PR fixes a bug so that the **local** `location` module is imported into the `cleanup` module. Also `pip-tools` is required for the DEV setup which is added to the readme