### PR TITLE
[Bug]: fix string argument for grass.message

### DIFF
--- a/src/grass_gis_helpers/general.py
+++ b/src/grass_gis_helpers/general.py
@@ -56,8 +56,10 @@ def log_memory(grassenv=None):
     )
     grass.message(
         _(
-            "\nDisk usage of GRASS GIS database:\n",
-            f"{cmd.communicate()[0].decode('utf-8').rstrip()}\n",
+            (
+                "\nDisk usage of GRASS GIS database:\n",
+                f"{cmd.communicate()[0].decode('utf-8').rstrip()}\n",
+            ),
         )
     )
 


### PR DESCRIPTION
PR fixes:
* a bug that two arguments were given to a grass.message instead of a single string