### PR TITLE
Avoid error on logging of empty messages

### DIFF
--- a/src/grass_gis_helpers/parallel.py
+++ b/src/grass_gis_helpers/parallel.py
@@ -70,7 +70,8 @@ def run_module_parallel(
         msg = proc.outputs["stderr"].value.strip()
         grass.message(_(f"\nLog of {proc.get_bash()}:"))
         for msg_part in msg.split("\n"):
-            grass.message(_(msg_part))
+            if len(msg_part) > 0:
+                grass.message(msg_part)
 
     # verify that switching the mapset worked
     location_path = verify_mapsets(start_cur_mapset)


### PR DESCRIPTION
Sometimes an error like this can be found in the logs (here tested with actinia):
```
"Prints a message, warning, progress info, or fatal error in the GRASS way.",
"",
"Usage:",
" g.message [-wedpiv] message=string [debug=value] [--help] [--verbose]",
"   [--quiet] [--ui]",
"",
"Flags:",
"  -w   Print message as warning",
"  -e   Print message as fatal error",
"  -d   Print message as debug message",
"  -p   Print message as progress info",
"  -i   Print message in all modes except of quiet mode",
"  -v   Print message only in verbose mode",
"",
"Parameters:",
"  message   Text of the message to be printed",
"    debug   Level to use for debug messages",
"            options: 0-5",
"            default: 1",
"",
"ERROR: Required parameter <message> not set:",
"\t(Text of the message to be printed)",
```
This happens when a worker is called and inside a module logs an empty line (which happens more frequently with `GRASS_MESSAGE_FORMAT=plain`). When the collected logs are printed by the calling module, the empty line leads to this error:
```
>>> import grass.script as grass
>>> grass.message("")
Prints a message, warning, progress info, or fatal error in the GRASS way.

Usage:
 g.message [-wedpiv] message=string [debug=value] [--help] [--verbose]
   [--quiet] [--ui]

Flags:
  -w   Print message as warning
  -e   Print message as fatal error
  -d   Print message as debug message
  -p   Print message as progress info
  -i   Print message in all modes except of quiet mode
  -v   Print message only in verbose mode

Parameters:
  message   Text of the message to be printed
    debug   Level to use for debug messages
            options: 0-5
            default: 1

ERROR: Required parameter <message> not set:
	(Text of the message to be printed)
```
This PR avoids the attempt to print the empty line.