### PR TITLE
Fix typos

### DIFF
--- a/src/grass_gis_helpers/data_import.py
+++ b/src/grass_gis_helpers/data_import.py
@@ -123,7 +123,7 @@ def import_local_raster_data(
         local_data_dir (str): Path to local data directory with VRT or TIF
                               files inside
         native_res_flag (bool): True if native data resolution should be used
-        all_raster (list/dict): Empty list/dictonary where the imported rasters
+        all_raster (list/dict): Empty list/dictionary where the imported rasters
                                 will be appended
         rm_rasters (list): List with rasters which should be removed
         band_dict (dict): Dictionary with band number and names, if none only
@@ -155,7 +155,7 @@ def import_local_raster_data(
     ns_res = cur_reg["nsres"]
     ew_res = cur_reg["ewres"]
     # import data for AOI
-    # TODO parallize local data import for multi TIFs/VRTs
+    # TODO parallelize local data import for multi TIFs/VRTs
     for i, raster_file in enumerate(raster_files):
         # set aoi if it is given with current resolution
         if aoi and aoi != "":
@@ -344,7 +344,7 @@ def import_local_xyz_files(
         aoi (str): Vector map with area of interest
         basename (str): Basename for imported rasters
         local_data_dir (str): Path to local data directory with XYZ files
-        all_raster (list/dict): empty list/dictonary where the imported rasters
+        all_raster (list/dict): empty list/dictionary where the imported rasters
                                 will be appended
     Returns:
         imported_local_data (bool): True if local data imported, otherwise False
@@ -359,7 +359,7 @@ def import_local_xyz_files(
     )
 
     # import data for AOI
-    # TODO parallize local data import
+    # TODO parallelize local data import
     # get current region
     cur_reg = grass.region()
     ns_res = cur_reg["nsres"]

--- a/src/grass_gis_helpers/general.py
+++ b/src/grass_gis_helpers/general.py
@@ -88,7 +88,7 @@ def free_ram(unit, percent=100):
     RAM memory and free swap space.
     Args:
         unit(string): 'GB' or 'MB'
-        percent(int): number of percent which shoud be used of the available
+        percent(int): number of percent which should be used of the available
                       RAM memory and free swap space
                       default 100%
     Returns:

--- a/src/grass_gis_helpers/open_geodata_germany/federal_state.py
+++ b/src/grass_gis_helpers/open_geodata_germany/federal_state.py
@@ -62,13 +62,13 @@ FS_ABBREVIATION = {
 
 def get_federal_states(federal_state, federal_state_file):
     """Get federal state and federal state file module parameters and return
-    list with federal state abbrevations
+    list with federal state abbreviations
 
     Args:
         federal_state (str): federal state module parameter
         federal_state_file (str): federal state file module parameter
     Returns:
-        (list): list with federale state abbrevations
+        (list): list with federale state abbreviations
 
     """
     if federal_state_file:


### PR DESCRIPTION
Fix a few typos using the [source code spell checker](https://github.com/OSGeo/grass/blob/main/utils/fix_typos.sh) available in the GRASS GIS `utils/` directory:

```
sh $HOME/software/grass_main/utils/fix_typos.sh
# ... interactive fixing of found typos by yes/no
./src/grass_gis_helpers/general.py
        percent(int): number of percent which shoud be used of the available
	shoud  ==> should (Y/n) y
FIXED: ./src/grass_gis_helpers/general.py
./src/grass_gis_helpers/data_import.py
        all_raster (list/dict): Empty list/dictonary where the imported rasters
	dictonary  ==> dictionary (Y/n) y
...

# cleanup of tmp dir
rm -rf fix_typos/
```