### PR TITLE
Parallel: Add error/warning functions

### DIFF
--- a/src/grass_gis_helpers/parallel.py
+++ b/src/grass_gis_helpers/parallel.py
@@ -48,7 +48,7 @@ def check_parallel_warnings(queue):
         stderr = mod.outputs["stderr"].value.strip()
         if "WARN" in stderr:
             grass.warning(
-                _(f"\nWARNING processing <{mod.get_bash()}>: {stderr}")
+                _(f"\nWARNING processing <{mod.get_bash()}>: {stderr}"),
             )
 
 

--- a/src/grass_gis_helpers/parallel.py
+++ b/src/grass_gis_helpers/parallel.py
@@ -42,8 +42,7 @@ def check_parallel_errors(queue):
 def check_parallel_warnings(queue):
     """Check a parallel queue for warnings in the worker modules by parsing
     the stderr output for warnings. A GRASS warning will be issued in this case.
-    To be used as except in a try/except block around a parallel GRASS
-    processing queue.
+    To be used after a successfully run processing queue.
     """
     for mod in queue.get_finished_modules():
         stderr = mod.outputs["stderr"].value.strip()

--- a/src/grass_gis_helpers/parallel.py
+++ b/src/grass_gis_helpers/parallel.py
@@ -22,6 +22,37 @@ from grass.pygrass.modules import Module, ParallelModuleQueue
 from .mapset import verify_mapsets
 
 
+def check_parallel_errors(queue):
+    """Check a parallel queue for errors in the worker modules by parsing
+    the stderr output for errors. A GRASS fatal will be thrown in this case.
+    To be used as except in a try/except block around a parallel GRASS
+    processing queue.
+    """
+    for proc_num in range(queue.get_num_run_procs()):
+        proc = queue.get(proc_num)
+        if proc.returncode != 0:
+            # save all stderr to a variable and pass it to a GRASS
+            # exception
+            errmsg = proc.outputs["stderr"].value.strip()
+            grass.fatal(
+                _(f"\nERROR processing <{proc.get_bash()}>: {errmsg}"),
+            )
+
+
+def check_parallel_warnings(queue):
+    """Check a parallel queue for warnings in the worker modules by parsing
+    the stderr output for warnings. A GRASS warning will be issued in this case.
+    To be used as except in a try/except block around a parallel GRASS
+    processing queue.
+    """
+    for mod in queue.get_finished_modules():
+        stderr = mod.outputs["stderr"].value.strip()
+        if "WARN" in stderr:
+            grass.warning(
+                _(f"\nWARNING processing <{mod.get_bash()}>: {stderr}")
+            )
+
+
 def run_module_parallel(
     module,
     module_kwargs,


### PR DESCRIPTION
Adds parsing of a parallel queue for Errors or Warnings. 
To be used in/after a try/except block around a parallel module processing queue, e.g.:

```
 queue = ParallelModuleQueue(nprocs=nprocs)
 try:
        for x in bla:
            worker = Module(
                "m.example.worker",
                param=x,
                new_mapset=new_mapset,
                run_=False,
            )
            worker.stdout_ = grass.PIPE
            worker.stderr_ = grass.PIPE
            queue.put(worker)
        queue.wait()
 except Exception:
        check_parallel_errors(queue)
 # needed to catch the warnings from the worker:
 check_parallel_warnings(queue)
```