### PR TITLE
Add location_size=False parameter to cleanup

### DIFF
--- a/How-to-create-a-GRASS-GIS-addon.md
+++ b/How-to-create-a-GRASS-GIS-addon.md
@@ -201,7 +201,7 @@ Choose a name depending on the "family":
 
 #### Linting
 
-- Add reusable linting workflow as described [here](https://github.com/mundialis/github-workflows?tab=readme-ov-file#python-linting)
+- Add reusable linting workflow as described [github-workflows](https://github.com/mundialis/github-workflows?tab=readme-ov-file#python-linting)
 
   ```yaml
   name: Python Flake8, black and pylint code quality check
@@ -239,12 +239,12 @@ Choose a name depending on the "family":
   - NOTE that variables should not go into the macro, e.g. `grass.message(_("Created output group <%s>") % output)` instead of `grass.message(_("Created output group <%s>" % output))`
 - There should be no space between the text and suspension points, e.g. `Reading raster map...` instead of `Reading raster map ...`
 
-For more information on standardized messages see [here](https://trac.osgeo.org/grass/wiki/MessageStandardization).
+For more information on standardized messages see [GRASS Message Standardization](https://trac.osgeo.org/grass/wiki/MessageStandardization).
 
 #### Tests
 
 - If tests exist, the header should look like in the actual module.
-- If tests exist, the test workflow should be included. [See here](https://github.com/mundialis/github-workflows?tab=readme-ov-file#grass-gis-addon-tests) for instructions.
+- If tests exist, the test workflow should be included. [github workflows - GRASS tests](https://github.com/mundialis/github-workflows?tab=readme-ov-file#grass-gis-addon-tests) for instructions.
 
 #### In the end
 

--- a/ruff.toml
+++ b/ruff.toml
@@ -44,4 +44,5 @@ lint.ignore = [
     "S603",
     "S604",
     "S605",
+    "S607",  # start-process-with-partial-path
 ]

--- a/src/grass_gis_helpers/cleanup.py
+++ b/src/grass_gis_helpers/cleanup.py
@@ -8,7 +8,7 @@
 #
 # PURPOSE:      lib with cleanup related helper functions for GRASS GIS
 #
-# COPYRIGHT:	(C) 2023 by mundialis and the GRASS Development Team
+# COPYRIGHT:	(C) 2023-2025 by mundialis and the GRASS Development Team
 #
 # 		This program is free software under the GNU General Public
 # 		License (>=v2). Read the file COPYING that comes with GRASS
@@ -39,6 +39,7 @@ def general_cleanup(
     rm_stvds_w_vectors=[],
     orig_region=None,
     rm_mask=False,
+    location_size=False,
 ):
     """General cleanup function."""
     grass.message(_("Cleaning up..."))
@@ -142,7 +143,8 @@ def general_cleanup(
         grass.run_command("r.mask", flags="r")
 
     # get location size
-    get_location_size()
+    if location_size:
+        get_location_size()
 
     # Garbage Collector: release unreferenced memory
     gc.collect()

--- a/src/grass_gis_helpers/general.py
+++ b/src/grass_gis_helpers/general.py
@@ -62,8 +62,7 @@ def log_memory(grassenv=None):
     if not grassenv:
         grassenv = grass.gisenv()
     cmd = subprocess.Popen(
-        f"df -h {grassenv['GISDBASE']}",
-        shell=True,
+        ["df", "-h", grassenv["GISDBASE"]],
         stdout=subprocess.PIPE,
     )
     grass.message(
@@ -78,7 +77,7 @@ def log_memory(grassenv=None):
     grass.message(_(f"\nmemory: \n{psutil.virtual_memory()!s}"))
     grass.message(_(f"\nswap memory: \n{psutil.swap_memory()!s}"))
     # ulimit -a
-    cmd = subprocess.Popen("ulimit -a", shell=True, stdout=subprocess.PIPE)
+    cmd = subprocess.Popen(["ulimit", "-a"], stdout=subprocess.PIPE)
     grass.message(
         _(f"\nulimit -a: \n{cmd.communicate()[0].decode('utf-8').rstrip()}"),
     )

--- a/src/grass_gis_helpers/location.py
+++ b/src/grass_gis_helpers/location.py
@@ -26,8 +26,7 @@ def get_location_size():
     """Log size of current location."""
     current_gisdbase = grass.gisenv()["GISDBASE"]
     cmd = subprocess.Popen(
-        f"df -h {current_gisdbase}",
-        shell=True,
+        ["df", "-h", current_gisdbase],
         stdout=subprocess.PIPE,
     )
     grass.message(

--- a/src/grass_gis_helpers/open_geodata_germany/download_data.py
+++ b/src/grass_gis_helpers/open_geodata_germany/download_data.py
@@ -74,8 +74,7 @@ def url_response(url):
     filename = os.path.basename(url)
     response = requests.get(url, stream=True)
     with open(str(filename), "wb") as f:
-        for chunk in response:
-            f.write(chunk)
+        f.writelines(response)
     return url
 
 


### PR DESCRIPTION
For large projects/locations the getting of the size take very long, so that it will no longer be printed automatacally.
For this, a parameter `location_size` is added which is by default `False`.